### PR TITLE
Fixed null pointer in the QueryBuilder caused by having no facet fields in the response

### DIFF
--- a/src/main/scala/jp/sf/amateras/solr/scala/QueryBuilder.scala
+++ b/src/main/scala/jp/sf/amateras/solr/scala/QueryBuilder.scala
@@ -91,11 +91,17 @@ class QueryBuilder(server: SolrServer, query: String) {
       }
     }
 
-    val facetResult =
-      response.getFacetFields().asScala.map { field => (
-        field.getName(),
-        field.getValues().asScala.map { value => (value.getName(), value.getCount()) }.toMap
-      )}.toMap
+    val facetFields = response.getFacetFields()
+    val facetResult = {
+      if (facetFields == null) {
+        Map.empty[String, Map[String, Long]]
+      } else {
+        facetFields.asScala.map { field => (
+          field.getName(),
+          field.getValues().asScala.map { value => (value.getName(), value.getCount()) }.toMap
+          )}.toMap
+      }
+    }
 
     MapQueryResult(queryResult, facetResult)
   }


### PR DESCRIPTION
I was running your client agains a real Solr server and kept getting null pointers in the response. It was being caused by response.getFacetFields() returning null.

Although I have no idea what facet fields are, since I am new to solr, but that fix made my code happy.
