### PR TITLE
Refactor AsyncSolrClient to support testing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ resolvers += "amateras-repo" at "http://amateras.sourceforge.jp/mvn/"
 resolvers += "Local Maven Repository" at "file:///"+Path.userHome.absolutePath+"/.m2/repository"
 
 libraryDependencies ++= Seq(
-  "org.apache.solr" % "solr-solrj" % "4.2.0" % "compile",
+  "org.apache.solr" % "solr-solrj" % "4.5.1" % "compile",
   "com.ning" % "async-http-client" % "1.7.16" % "compile",
   "org.scalatest" %% "scalatest" % "1.9.1" % "test",
   "org.mockito" % "mockito-core" % "1.9.0" % "test",

--- a/src/main/scala/jp/sf/amateras/solr/scala/QueryBuilderBase.scala
+++ b/src/main/scala/jp/sf/amateras/solr/scala/QueryBuilderBase.scala
@@ -19,7 +19,7 @@ abstract class QueryBuilderBase(query: String)(implicit parser: ExpressionParser
   /**
    * Sets the field name of the unique key.
    * 
-   * @param the field name of the unique key (default is "id").
+   * @param id the field name of the unique key (default is "id").
    */
   def id(id: String): this.type = {
     this.id = id
@@ -45,14 +45,14 @@ abstract class QueryBuilderBase(query: String)(implicit parser: ExpressionParser
    * @param order the sorting order
    */
   def sortBy[T <: QueryBuilderBase](field: String, order: Order): this.type = {
-    solrQuery.addSortField(field, order)
+    solrQuery.setSort(field, order)
     this
   }
 
   /**
    * Sets grouping field names.
    *
-   * @param grouping field names
+   * @param fields field names
    */
   def groupBy[T <: QueryBuilderBase](fields: String*): this.type = {
     if(fields.size > 0){

--- a/src/main/scala/jp/sf/amateras/solr/scala/async/AbstractAsyncQueryBuilder.scala
+++ b/src/main/scala/jp/sf/amateras/solr/scala/async/AbstractAsyncQueryBuilder.scala
@@ -1,0 +1,21 @@
+package jp.sf.amateras.solr.scala.async
+
+import jp.sf.amateras.solr.scala.query.{ExpressionParser, QueryTemplate}
+import jp.sf.amateras.solr.scala.{QueryBuilderBase, CaseClassMapper, CaseClassQueryResult, MapQueryResult}
+import org.apache.solr.client.solrj.SolrQuery
+import org.apache.solr.client.solrj.response.QueryResponse
+import scala.concurrent.Future
+
+abstract class AbstractAsyncQueryBuilder(query: String)(implicit parser: ExpressionParser) extends QueryBuilderBase(query) {
+    def getResultAsMap(params: Any = null): Future[MapQueryResult] = {
+        solrQuery.setQuery(new QueryTemplate(query).merge(CaseClassMapper.toMap(params)))
+        query(solrQuery, { response => responseToMap(response) })
+    }
+
+    def getResultAs[T](params: Any = null)(implicit m: Manifest[T]): Future[CaseClassQueryResult[T]] = {
+        solrQuery.setQuery(new QueryTemplate(query).merge(CaseClassMapper.toMap(params)))
+        query(solrQuery, { response => responseToObject[T](response) })
+    }
+
+    protected def query[T](solrQuery: SolrQuery, success: QueryResponse => T): Future[T]
+}

--- a/src/main/scala/jp/sf/amateras/solr/scala/async/AsyncQueryBuilder.scala
+++ b/src/main/scala/jp/sf/amateras/solr/scala/async/AsyncQueryBuilder.scala
@@ -1,28 +1,18 @@
 package jp.sf.amateras.solr.scala.async
 
-import scala.concurrent._
-import org.apache.solr.client.solrj._
-import org.apache.solr.client.solrj.response.QueryResponse
-import org.apache.solr.client.solrj.impl.XMLResponseParser
-import jp.sf.amateras.solr.scala._
-import jp.sf.amateras.solr.scala.query._
 import AsyncUtils._
-import java.net.URLEncoder
 import com.ning.http.client._
+import java.net.URLEncoder
+import jp.sf.amateras.solr.scala.query._
+import org.apache.solr.client.solrj._
+import org.apache.solr.client.solrj.impl.XMLResponseParser
+import org.apache.solr.client.solrj.response.QueryResponse
+import scala.concurrent._
 
-class AsyncQueryBuilder(httpClient: AsyncHttpClient, url: String, query: String)(implicit parser: ExpressionParser) extends QueryBuilderBase(query) {
+class AsyncQueryBuilder(httpClient: AsyncHttpClient, url: String, protected val query: String)
+                       (implicit parser: ExpressionParser) extends AbstractAsyncQueryBuilder(query) {
 
-  def getResultAsMap(params: Any = null): Future[MapQueryResult] = {
-    solrQuery.setQuery(new QueryTemplate(query).merge(CaseClassMapper.toMap(params)))
-    query(solrQuery, { response => responseToMap(response) })
-  }
-  
-  def getResultAs[T](params: Any = null)(implicit m: Manifest[T]): Future[CaseClassQueryResult[T]] = {
-    solrQuery.setQuery(new QueryTemplate(query).merge(CaseClassMapper.toMap(params)))
-    query(solrQuery, { response => responseToObject[T](response) })
-  }
-  
-  private def query[T](solrQuery: SolrQuery, success: QueryResponse => T): Future[T] = {
+    protected def query[T](solrQuery: SolrQuery, success: QueryResponse => T): Future[T] = {
     val promise = Promise[T]()
     
     httpClient.prepareGet(url + "/select?q=" + URLEncoder.encode(solrQuery.getQuery, "UTF-8") + "&wt=xml")
@@ -36,6 +26,4 @@ class AsyncQueryBuilder(httpClient: AsyncHttpClient, url: String, query: String)
     
     promise.future
   }
-  
-  
 }

--- a/src/main/scala/jp/sf/amateras/solr/scala/async/AsyncSolrClient.scala
+++ b/src/main/scala/jp/sf/amateras/solr/scala/async/AsyncSolrClient.scala
@@ -1,98 +1,29 @@
 package jp.sf.amateras.solr.scala.async
 
-import scala.concurrent._
-import scala.concurrent.ExecutionContext.Implicits.global
-import AsyncUtils._
-import jp.sf.amateras.solr.scala.query._
-import jp.sf.amateras.solr.scala.CaseClassMapper
 import com.ning.http.client.AsyncHttpClient
-import org.apache.solr.common.SolrInputDocument
-import org.apache.solr.client.solrj.impl.XMLResponseParser
-import org.apache.solr.client.solrj.request.UpdateRequest
-import org.apache.solr.client.solrj.request.AbstractUpdateRequest
-import org.apache.solr.client.solrj.response.QueryResponse
 import java.net.URLEncoder
-import scala.util.Success
-import scala.util.Failure
+import jp.sf.amateras.solr.scala.CaseClassMapper
+import jp.sf.amateras.solr.scala.async.AsyncUtils.CallbackHandler
+import jp.sf.amateras.solr.scala.query._
+import org.apache.solr.client.solrj.request.{AbstractUpdateRequest, UpdateRequest}
+import org.apache.solr.common.SolrInputDocument
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent._
+import scala.util.{Success, Failure}
 
 /**
  * Provides the asynchronous and non-blocking API for Solr.
  */
 class AsyncSolrClient(url: String, factory: () => AsyncHttpClient = { () => new AsyncHttpClient() })
-    (implicit parser: ExpressionParser = new DefaultExpressionParser()) {
+    (implicit protected val parser: ExpressionParser = new DefaultExpressionParser()) extends IAsyncSolrClient {
   
   val httpClient: AsyncHttpClient = factory()
-  
-  /**
-   * Execute given operation in the transaction.
-   * 
-   * The transaction is committed if operation was successful. 
-   * But the transaction is rolled back if an error occurred.
-   */
-  def withTransaction[T](operations:  => Future[T]): Future[T] = {
-    val future = operations
-    future.onComplete {
-      case Success(x) => commit
-      case Failure(t) => rollback
-    }
-    future
-  }
   
   /**
    * Search documents using the given query.
    */
   def query(query: String): AsyncQueryBuilder = new AsyncQueryBuilder(httpClient, url, query)
-  
-  /**
-   * Add the document.
-   *
-   * @param doc the document to register
-   */
-  def add(doc: Any): Future[Unit] = {
-    val solrDoc = new SolrInputDocument
-    CaseClassMapper.toMap(doc).map { case (key, value) =>
-      solrDoc.addField(key, value)
-    }
 
-    val req = new UpdateRequest()
-    req.add(solrDoc)
-    execute(httpClient, req, Promise[Unit]())
-  }
-  
-  /**
-   * Add the document and commit them immediately.
-   *
-   * @param doc the document to register
-   */
-  def register(doc: Any): Future[Unit] = {
-    withTransaction {
-      add(doc)
-    }
-  }
-  
-  /**
-   * Delete the document which has a given id.
-   *
-   * @param id the identifier of the document to delete
-   */
-  def deleteById(id: String): Future[Unit] = {
-    val req = new UpdateRequest()
-    req.deleteById(id)
-    execute(httpClient, req, Promise[Unit]())
-  }
-  
-  /**
-   * Delete documents by the given query.
-   *
-   * @param query the solr query to select documents which would be deleted
-   * @param params the parameter map which would be given to the query
-   */
-  def deleteByQuery(query: String, params: Map[String, Any] = Map()): Future[Unit] = {
-    val req = new UpdateRequest()
-    req.deleteByQuery(new QueryTemplate(query).merge(params))
-    execute(httpClient, req, Promise[Unit]())
-  }
-  
   /**
    * Commit the current session.
    */
@@ -115,8 +46,12 @@ class AsyncSolrClient(url: String, factory: () => AsyncHttpClient = { () => new 
    * Call this method before stopping your application.
    */
   def shutdown(): Unit = httpClient.closeAsynchronously()
-  
-  /**
+
+    override protected def execute(req: UpdateRequest, promise: Promise[Unit]): Future[Unit] = {
+        execute(httpClient, req, promise)
+    }
+
+    /**
    * Send request using AsyncHttpClient.
    * Returns the result of asynchronous request to the future world via given Promise.
    */
@@ -133,10 +68,10 @@ class AsyncSolrClient(url: String, factory: () => AsyncHttpClient = { () => new 
       
     } else {
       // Send URL encoded parameters as request body
-      builder.addHeader("Content-Charset", "UTF-8");
+      builder.addHeader("Content-Charset", "UTF-8")
       builder.addHeader("Content-Type", "application/x-www-form-urlencoded; charset=UTF-8")
-      import scala.collection.JavaConverters._
-      val params = req.getParams()
+        import scala.collection.JavaConverters._
+        val params = req.getParams
       builder.setBody(params.getParameterNames.asScala.map { name =>
         URLEncoder.encode(name, "UTF-8") + "=" + URLEncoder.encode(params.get(name), "UTF-8")
       }.mkString("&"))

--- a/src/main/scala/jp/sf/amateras/solr/scala/async/IAsyncSolrClient.scala
+++ b/src/main/scala/jp/sf/amateras/solr/scala/async/IAsyncSolrClient.scala
@@ -1,0 +1,100 @@
+package jp.sf.amateras.solr.scala.async
+
+import scala.concurrent.{Promise, Future}
+import scala.util.{Failure, Success}
+import jp.sf.amateras.solr.scala.query.{QueryTemplate, ExpressionParser}
+import org.apache.solr.client.solrj.request.UpdateRequest
+import jp.sf.amateras.solr.scala.CaseClassMapper
+import org.apache.solr.common.SolrInputDocument
+
+trait IAsyncSolrClient {
+    protected implicit def parser: ExpressionParser
+    /**
+     * Execute given operation in the transaction.
+     *
+     * The transaction is committed if operation was successful.
+     * But the transaction is rolled back if an error occurred.
+     */
+    def withTransaction[T](operations: => Future[T]): Future[T] = {
+        import scala.concurrent.ExecutionContext.Implicits.global
+
+        val p = Promise[T]()
+        operations onComplete {
+            case Success(x) => commit() onComplete {
+                case Success(_) => p success x
+                case Failure(t) => p failure t
+            }
+
+            case Failure(t) => rollback() onComplete (_ => p failure t)
+        }
+
+        p.future
+    }
+
+    protected def execute(req: UpdateRequest, promise: Promise[Unit]): Future[Unit]
+
+    def query(query: String): AbstractAsyncQueryBuilder
+
+    /**
+     * Add the document.
+     *
+     * @param doc the document to register
+     */
+    def add(doc: Any): Future[Unit] = {
+        val solrDoc = doc match {
+            case sid: SolrInputDocument => sid
+            case _ =>
+                val ret = new SolrInputDocument
+                CaseClassMapper.toMap(doc) map {
+                    case (key, value) => ret.addField(key, value)
+                }
+                ret
+        }
+
+        val req = new UpdateRequest()
+        req.add(solrDoc)
+        execute(req, Promise[Unit]())
+    }
+
+    /**
+     * Add the document and commit them immediately.
+     *
+     * @param doc the document to register
+     */
+    def register(doc: Any): Future[Unit] = {
+        withTransaction {
+            add(doc)
+        }
+    }
+
+    /**
+     * Delete the document which has a given id.
+     *
+     * @param id the identifier of the document to delete
+     */
+    def deleteById(id: String): Future[Unit] = {
+        val req = new UpdateRequest()
+        req.deleteById(id)
+        execute(req, Promise[Unit]())
+    }
+
+
+    /**
+     * Delete documents by the given query.
+     *
+     * @param query the solr query to select documents which would be deleted
+     * @param params the parameter map which would be given to the query
+     */
+    def deleteByQuery(query: String, params: Map[String, Any] = Map()): Future[Unit] = {
+        val req = new UpdateRequest()
+        req.deleteByQuery(new QueryTemplate(query).merge(params))
+        execute(req, Promise[Unit]())
+    }
+
+
+    def commit(): Future[Unit]
+
+    def rollback(): Future[Unit]
+
+    def shutdown(): Unit
+}


### PR DESCRIPTION
Hi, I've been testing out your library and definitely like it, I just wondered if you might roll this commit in so we don't have to maintain a branch (and hey, other people might find it useful).

Basically I have a lot of unit tests that start an EmbeddedSolrServer, load data, run tests, then shutdown. With AsyncSolrClient and AsyncQueryBuilder being concrete, I couldn't write unit tests using this library, so I factored out a trait and an abstract class that made it easy for me to plug in an EmbeddedSolrServer for query(), commit(), rollback(), and shutdown(), manually wrapped in futures. I've not started using solr-scala-client extensively yet, but so far it's passed all the tests I've written.

I also changed withTransaction() to not complete the returned future until after the commit() or rollback() has completed.
1. Bump SolrJ version from 4.2.0 to 4.5.1
2. Refactor AsyncSolrClient & AsyncQueryBuilder into a trait (IAsyncSolrClient) and an abstract class (AbstractAsyncQueryBuilder) which allows us to plug in an EmbeddedSolrServer for testing purposes
3. Modify [I]AsyncSolrClient.withTransaction to not complete the future until the commit() or rollback() has completed
