### PR TITLE
AsyncQueryBuilder fixes and immutable QueryBuilders

### DIFF
--- a/src/main/scala/jp/sf/amateras/solr/scala/QueryBuilder.scala
+++ b/src/main/scala/jp/sf/amateras/solr/scala/QueryBuilder.scala
@@ -1,19 +1,13 @@
 package jp.sf.amateras.solr.scala
 
-import scala.collection.JavaConverters.asScalaBufferConverter
-import scala.collection.JavaConverters.collectionAsScalaIterableConverter
-
-import org.apache.solr.client.solrj.SolrQuery
-import org.apache.solr.client.solrj.SolrServer
-import org.apache.solr.common.SolrDocumentList
-import org.apache.solr.common.SolrDocument
-import org.apache.solr.common.util.NamedList
-
 import jp.sf.amateras.solr.scala.query.ExpressionParser
 import jp.sf.amateras.solr.scala.query.QueryTemplate
-import org.apache.solr.client.solrj.response.QueryResponse
+import org.apache.solr.client.solrj.SolrServer
 
-class QueryBuilder(server: SolrServer, query: String)(implicit parser: ExpressionParser) extends QueryBuilderBase(query) {
+class QueryBuilder(server: SolrServer, query: String)(implicit parser: ExpressionParser)
+  extends QueryBuilderBase[QueryBuilder] {
+
+  protected def createCopy = new QueryBuilder(server, query)(parser)
 
   /**
    * Returns the search result of this query as List[Map[String, Any]].

--- a/src/main/scala/jp/sf/amateras/solr/scala/async/AbstractAsyncQueryBuilder.scala
+++ b/src/main/scala/jp/sf/amateras/solr/scala/async/AbstractAsyncQueryBuilder.scala
@@ -2,11 +2,13 @@ package jp.sf.amateras.solr.scala.async
 
 import jp.sf.amateras.solr.scala.query.{ExpressionParser, QueryTemplate}
 import jp.sf.amateras.solr.scala.{QueryBuilderBase, CaseClassMapper, CaseClassQueryResult, MapQueryResult}
-import org.apache.solr.client.solrj.SolrQuery
 import org.apache.solr.client.solrj.response.QueryResponse
+import org.apache.solr.common.params.SolrParams
 import scala.concurrent.Future
 
-abstract class AbstractAsyncQueryBuilder(query: String)(implicit parser: ExpressionParser) extends QueryBuilderBase(query) {
+abstract class AbstractAsyncQueryBuilder(query: String)(implicit parser: ExpressionParser)
+    extends QueryBuilderBase[AbstractAsyncQueryBuilder] {
+
     def getResultAsMap(params: Any = null): Future[MapQueryResult] = {
         solrQuery.setQuery(new QueryTemplate(query).merge(CaseClassMapper.toMap(params)))
         query(solrQuery, { response => responseToMap(response) })
@@ -17,5 +19,5 @@ abstract class AbstractAsyncQueryBuilder(query: String)(implicit parser: Express
         query(solrQuery, { response => responseToObject[T](response) })
     }
 
-    protected def query[T](solrQuery: SolrQuery, success: QueryResponse => T): Future[T]
+    protected def query[T](solrQuery: SolrParams, success: QueryResponse => T): Future[T]
 }

--- a/src/main/scala/jp/sf/amateras/solr/scala/async/AsyncQueryBuilder.scala
+++ b/src/main/scala/jp/sf/amateras/solr/scala/async/AsyncQueryBuilder.scala
@@ -2,20 +2,24 @@ package jp.sf.amateras.solr.scala.async
 
 import AsyncUtils._
 import com.ning.http.client._
-import java.net.URLEncoder
 import jp.sf.amateras.solr.scala.query._
-import org.apache.solr.client.solrj._
 import org.apache.solr.client.solrj.impl.XMLResponseParser
 import org.apache.solr.client.solrj.response.QueryResponse
+import org.apache.solr.client.solrj.util.ClientUtils
+import org.apache.solr.common.params.SolrParams
 import scala.concurrent._
 
 class AsyncQueryBuilder(httpClient: AsyncHttpClient, url: String, protected val query: String)
                        (implicit parser: ExpressionParser) extends AbstractAsyncQueryBuilder(query) {
 
-    protected def query[T](solrQuery: SolrQuery, success: QueryResponse => T): Future[T] = {
+    protected def createCopy = new AsyncQueryBuilder(httpClient, url, query)(parser)
+
+    protected def query[T](solrQuery: SolrParams, success: QueryResponse => T): Future[T] = {
     val promise = Promise[T]()
     
-    httpClient.prepareGet(url + "/select?q=" + URLEncoder.encode(solrQuery.getQuery, "UTF-8") + "&wt=xml")
+    httpClient.preparePost(url + "/select")
+      .setHeader("Content-Type", "application/x-www-form-urlencoded")
+      .setBody((ClientUtils.toQueryString(solrQuery, false) + "&wt=xml").getBytes("UTF-8"))
       .execute(new CallbackHandler(httpClient, promise, (response: Response) => {
           val parser = new XMLResponseParser
           val namedList = parser.processResponse(response.getResponseBodyAsStream, "UTF-8")

--- a/src/main/scala/jp/sf/amateras/solr/scala/async/AsyncSolrClient.scala
+++ b/src/main/scala/jp/sf/amateras/solr/scala/async/AsyncSolrClient.scala
@@ -2,7 +2,7 @@ package jp.sf.amateras.solr.scala.async
 
 import com.ning.http.client.AsyncHttpClient
 import java.net.URLEncoder
-import jp.sf.amateras.solr.scala.CaseClassMapper
+import jp.sf.amateras.solr.scala.{QueryBuilderBase, CaseClassMapper}
 import jp.sf.amateras.solr.scala.async.AsyncUtils.CallbackHandler
 import jp.sf.amateras.solr.scala.query._
 import org.apache.solr.client.solrj.request.{AbstractUpdateRequest, UpdateRequest}
@@ -15,14 +15,15 @@ import scala.util.{Success, Failure}
  * Provides the asynchronous and non-blocking API for Solr.
  */
 class AsyncSolrClient(url: String, factory: () => AsyncHttpClient = { () => new AsyncHttpClient() })
-    (implicit protected val parser: ExpressionParser = new DefaultExpressionParser()) extends IAsyncSolrClient {
+    (implicit protected val parser: ExpressionParser = new DefaultExpressionParser())
+    extends IAsyncSolrClient {
   
   val httpClient: AsyncHttpClient = factory()
   
   /**
    * Search documents using the given query.
    */
-  def query(query: String): AsyncQueryBuilder = new AsyncQueryBuilder(httpClient, url, query)
+  def query(query: String) = new AsyncQueryBuilder(httpClient, url, query)
 
   /**
    * Commit the current session.


### PR DESCRIPTION
1. AsyncQueryBuilder was only using the q parameter of the query, discarding rows/sort/fields/etc - use Solr's ClientUtils.toQueryString
2. change AsyncQueryBuilder to POST the query instead of GET - allows large queries to be run
3. allow any SolrParams object to be used for querying instead of requiring a SolrQuery object
4. change QueryBuilderBase methods to return copies of the query builder instead of modifying the object. Besides immutability generally being good, this allows (for instance) a use case of taking in a partially built QueryBuilder and then easily send out copies to other threads to run queries with different start points / row counts / parameter maps
