### PR TITLE
Add shutdown to SolrClient to release allocated resources

### DIFF
--- a/src/main/scala/jp/sf/amateras/solr/scala/SolrClient.scala
+++ b/src/main/scala/jp/sf/amateras/solr/scala/SolrClient.scala
@@ -17,6 +17,11 @@ class SolrClient(url: String)
   //initializer(server)
 
   /**
+   * Shutdown this solr client to release allocated resources.
+   */
+  def shutdown(): Unit = server.shutdown
+
+  /**
    * Execute given operation in the transaction.
    * 
    * The transaction is committed if operation was successful. 


### PR DESCRIPTION
The SolrClient currently does not allow to release allocated resources, this is fixed by this PR.
