### PR TITLE
Expose setRequestHandler() method of the SolrQuery

### DIFF
--- a/src/main/scala/jp/sf/amateras/solr/scala/QueryBuilderBase.scala
+++ b/src/main/scala/jp/sf/amateras/solr/scala/QueryBuilderBase.scala
@@ -35,7 +35,19 @@ trait QueryBuilderBase[Repr <: QueryBuilderBase[Repr]] {
   def id(id: String): Repr = {
     copy(newId = id)
   }
-    
+
+
+  /**
+   * Sets the RequestHandler for the Solr query
+   *
+   * @param handler the name of the RequestHandler as defined in solrconfig.xml (default is "/select").
+   */
+  def setRequestHandler(handler: String): Repr = {
+    val ret = copy()
+    ret.solrQuery.setRequestHandler(handler)
+    ret
+  }
+  
   /**
    * Sets field names to retrieve by this query.
    *


### PR DESCRIPTION
Allow to utilize RequestHandlers other than the default
