### PR TITLE
Number of snippets in highlighting. Error if there is no id specified on...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ project/plugins/project/
 # IntelliJ IDEA specific
 .idea/*
 .idea_modules/*
+*.iml

--- a/src/main/scala/jp/sf/amateras/solr/scala/QueryBuilderBase.scala
+++ b/src/main/scala/jp/sf/amateras/solr/scala/QueryBuilderBase.scala
@@ -130,11 +130,13 @@ trait QueryBuilderBase[Repr <: QueryBuilderBase[Repr]] {
    * @param prefix the prefix of highlighted ranges
    * @param postfix the postfix of highlighted ranges
    */
-  def highlight(field: String, size: Int = 100, prefix: String = "", postfix: String = ""): Repr = {
+  def highlight(field: String, size: Int = 100,
+                prefix: String = "", postfix: String = "",
+                snippets: Int = 1): Repr = {
     val ret = copy(newHighlightField = field)
     ret.solrQuery.setHighlight(true)
     ret.solrQuery.addHighlightField(field)
-    ret.solrQuery.setHighlightSnippets(1)
+    ret.solrQuery.setHighlightSnippets(snippets)
     ret.solrQuery.setHighlightFragsize(size)
     if(prefix.nonEmpty){
       ret.solrQuery.setHighlightSimplePre(prefix)
@@ -171,9 +173,9 @@ trait QueryBuilderBase[Repr <: QueryBuilderBase[Repr]] {
         if(solrQuery.getHighlight()){
           val id = doc.getFieldValue(this.id)
           if(id != null && highlight.get(id) != null && highlight.get(id).get(highlightField) != null){
-            map + ("highlight" -> highlight.get(id).get(highlightField).get(0))
+            map + ("highlights" -> highlight.get(id).get(highlightField))
           } else {
-            map + ("highlight" -> "")
+            throw new UnspecifiedIdError
           }
         } else {
           map

--- a/src/main/scala/jp/sf/amateras/solr/scala/UnspecifiedIdError.scala
+++ b/src/main/scala/jp/sf/amateras/solr/scala/UnspecifiedIdError.scala
@@ -1,0 +1,7 @@
+package jp.sf.amateras.solr.scala
+
+/**
+ * Exception that denotes that an ID was required, but not specified.
+ */
+class UnspecifiedIdError
+  extends Exception("When returning highlights, the ID of the document must be specified")

--- a/src/test/scala/jp/sf/amateras/solr/scala/QueryBuilderBaseSuite.scala
+++ b/src/test/scala/jp/sf/amateras/solr/scala/QueryBuilderBaseSuite.scala
@@ -9,7 +9,7 @@ class QueryBuilderBaseSuite extends FunSuite {
     val server = SolrServerFactory.dummy(request => ())
     implicit val parser = new DefaultExpressionParser()
     val queryBuilder = new TestQueryBuilder()
-    val copied = queryBuilder.id("contentId").highlight("content", 200, "<b>", "</b>")
+    val copied = queryBuilder.id("contentId").highlight("content", 200, "<b>", "</b>", 2)
     
     assert(copied.getId == "contentId")
     assert(copied.getHilightingField == "content")
@@ -18,6 +18,7 @@ class QueryBuilderBaseSuite extends FunSuite {
     assert(copied.getQuery.getHighlightFields()(0) == "content")
     assert(copied.getQuery.getHighlightSimplePre() == "<b>")
     assert(copied.getQuery.getHighlightSimplePost() == "</b>")
+    assert(copied.getQuery.getHighlightSnippets == 2)
   }
   
   class TestQueryBuilder extends QueryBuilderBase[TestQueryBuilder]{


### PR DESCRIPTION
Think number of snippets might be helpful for some projects. What you might be put off by is the change of "highlight" to "highlights" in the document map and the use of an error if there is no ID specified when returning the highlighted values.

The reason for the error is that first time users may wonder why the results are blank when not specifying an ID (although it's kind of in the docs).
