### PR TITLE
async-http-client 2.0.24 -> 2.0.37

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ resolvers += "Local Maven Repository" at "file:///" + Path.userHome.absolutePath
 
 libraryDependencies ++= Seq(
   "org.apache.solr"         % "solr-solrj"               % "6.3.0"   % "compile",
-  "org.asynchttpclient"     % "async-http-client"        % "2.0.24"  % "compile",
+  "org.asynchttpclient"     % "async-http-client"        % "2.0.37"  % "compile",
   "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.4",
   "org.scalatest"          %% "scalatest"                % "3.0.1"   % "test",
   "org.mockito"             % "mockito-core"             % "2.2.22"  % "test",


### PR DESCRIPTION
fix a security vulnerability of async-http-client.
See below link(at later async-http-client 2.0.35, fix a security vulnerability.)

https://github.com/AsyncHttpClient/async-http-client/issues/1455