### PR TITLE
More collections

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "solr-scala-client"
 
-organization := "com.github.takezoe"
+organization := "jeffdyke"
 
 version := "0.0.20"
 
@@ -21,15 +21,15 @@ libraryDependencies ++= Seq(
   "commons-logging"         % "commons-logging"          % "1.2"         % "runtime"
 )
 
-publishMavenStyle := true
+//publishMavenStyle := true
 
-publishTo := {
-  val nexus = "https://oss.sonatype.org/"
-  if (version.value.trim.endsWith("SNAPSHOT"))
-    Some("snapshots" at nexus + "content/repositories/snapshots")
-  else
-    Some("releases"  at nexus + "service/local/staging/deploy/maven2")
-}
+//publishTo := {
+//  val nexus = "https://oss.sonatype.org/"
+//  if (version.value.trim.endsWith("SNAPSHOT"))
+//    Some("snapshots" at nexus + "content/repositories/snapshots")
+//  else
+//    Some("releases"  at nexus + "service/local/staging/deploy/maven2")
+//}
 
 scalacOptions := Seq("-deprecation", "-feature")
 
@@ -38,7 +38,7 @@ publishArtifact in Test := false
 pomIncludeRepository := { _ => false }
 
 pomExtra := (
-  <url>https://github.com/takezoe/solr-scala-client</url>
+  <url>https://github.com/jeffdyke/solr-scala-client</url>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
@@ -46,13 +46,13 @@ pomExtra := (
     </license>
   </licenses>
   <scm>
-    <url>https://github.com/takezoe/solr-scala-client</url>
-    <connection>scm:git:https://github.com/takezoe/solr-scala-client.git</connection>
+    <url>https://github.com/jeffdyke/solr-scala-client</url>
+    <connection>scm:git:https://github.com/jeffdyke/solr-scala-client.git</connection>
   </scm>
   <developers>
     <developer>
-      <id>takezoe</id>
-      <name>Naoki Takezoe</name>
+      <id>jeffdyke</id>
+      <name>Jeff Dyke</name>
     </developer>
   </developers>
 )

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "solr-scala-client"
 
 organization := "com.github.takezoe"
 
-version := "0.0.19"
+version := "0.0.20"
 
 scalaVersion := "2.12.7"
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.1
+sbt.version=1.2.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,2 @@
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")
+addSbtPlugin("ohnosequences" % "sbt-github-release" % "0.6.0")

--- a/src/main/scala/com/github/takezoe/solr/scala/BatchRegister.scala
+++ b/src/main/scala/com/github/takezoe/solr/scala/BatchRegister.scala
@@ -21,7 +21,7 @@ class BatchRegister(server: ApacheSolrClient, collection: Option[String], docs: 
 
   def commit(): UpdateResponse = server.commit
 
-  def commitCollection(collection: String): UpdateResponse = server.commit(collection)
+  def commit(collection: String): UpdateResponse = server.commit(collection)
 
   def rollback(): UpdateResponse = server.rollback
 

--- a/src/main/scala/com/github/takezoe/solr/scala/BatchRegister.scala
+++ b/src/main/scala/com/github/takezoe/solr/scala/BatchRegister.scala
@@ -1,5 +1,6 @@
 package com.github.takezoe.solr.scala
 
+import org.apache.solr.client.solrj.response.UpdateResponse
 import org.apache.solr.client.solrj.{SolrClient => ApacheSolrClient}
 import org.apache.solr.common.SolrInputDocument
 
@@ -10,7 +11,7 @@ class BatchRegister(server: ApacheSolrClient, collection: Option[String], docs: 
   def add(docs: Any*): BatchRegister = {
     CaseClassMapper.toMapArray(docs: _*).foreach { doc =>
       val solrDoc = new SolrInputDocument
-      doc.map { case (key, value) =>
+      doc.collect { case (key, value) =>
         solrDoc.addField(key, value)
       }
       server.add(collection.orNull, solrDoc)
@@ -18,8 +19,10 @@ class BatchRegister(server: ApacheSolrClient, collection: Option[String], docs: 
     this
   }
 
-  def commit(): Unit = server.commit
+  def commit(): UpdateResponse = server.commit
 
-  def rollback(): Unit = server.rollback
+  def commitCollection(collection: String): UpdateResponse = server.commit(collection)
+
+  def rollback(): UpdateResponse = server.rollback
 
 }

--- a/src/main/scala/com/github/takezoe/solr/scala/BatchRegister.scala
+++ b/src/main/scala/com/github/takezoe/solr/scala/BatchRegister.scala
@@ -16,6 +16,8 @@ class BatchRegister(server: ApacheSolrClient, collection: Option[String], docs: 
       collection match {
         case Some(c) => server.add(c, solrDoc)
         case None => server.add(solrDoc)
+
+
       }
     }
     this

--- a/src/main/scala/com/github/takezoe/solr/scala/BatchRegister.scala
+++ b/src/main/scala/com/github/takezoe/solr/scala/BatchRegister.scala
@@ -4,8 +4,7 @@ import org.apache.solr.client.solrj.response.UpdateResponse
 import org.apache.solr.client.solrj.{SolrClient => ApacheSolrClient}
 import org.apache.solr.common.SolrInputDocument
 
-class BatchRegister(server: ApacheSolrClient, collection: Option[String], docs: Map[String, Any]*){
-
+class BatchRegister(server: ApacheSolrClient, collection: Option[String], docs: Map[String, Any]*) {
   add(docs: _*)
 
   def add(docs: Any*): BatchRegister = {
@@ -14,7 +13,10 @@ class BatchRegister(server: ApacheSolrClient, collection: Option[String], docs: 
       doc.collect { case (key, value) =>
         solrDoc.addField(key, value)
       }
-      server.add(collection.orNull, solrDoc)
+      collection match {
+        case Some(c) => server.add(c, solrDoc)
+        case None => server.add(solrDoc)
+      }
     }
     this
   }

--- a/src/main/scala/com/github/takezoe/solr/scala/SolrClient.scala
+++ b/src/main/scala/com/github/takezoe/solr/scala/SolrClient.scala
@@ -42,13 +42,10 @@ class SolrClient(url: String)
   /**
     * Execute given operation in the transaction to a collection
     *
-    * I'm not a huge fan of this function as you can still get an NPE, if your operations are not properly constructed.
-    * That said, support for the collection mode should be supported for all functionality.
-    *
     * The transaction is committed if operation was successful.
     * But the transaction is rolled back if an error occurred.
     */
-  def withTransactionOnCollection[T](operations: => T, collection: String): T = {
+  def withTransactionOnCollection[T](collection: String)(operations: => T): T = {
     try {
       val result = operations
       commit(collection)

--- a/src/main/scala/com/github/takezoe/solr/scala/SolrClientFactory.scala
+++ b/src/main/scala/com/github/takezoe/solr/scala/SolrClientFactory.scala
@@ -35,10 +35,10 @@ object SolrClientFactory {
 
     client
   }
-  
+
   /**
    * Provides the dummy HttpSolrClient for unit testing.
-   * 
+   *
    * {{{
    * implicit val solr = SolrClientFactory.dummy { request =>
    *   println(request.getMethod)

--- a/src/main/scala/com/github/takezoe/solr/scala/async/AsyncQueryBuilder.scala
+++ b/src/main/scala/com/github/takezoe/solr/scala/async/AsyncQueryBuilder.scala
@@ -42,7 +42,7 @@ class AsyncQueryBuilder(httpClient: OkHttpClient, url: String, protected val que
       queryResponse.setResponse(namedList)
       success(queryResponse)
     }))
-    
+
     promise.future
   }
 

--- a/src/main/scala/com/github/takezoe/solr/scala/async/AsyncSolrClient.scala
+++ b/src/main/scala/com/github/takezoe/solr/scala/async/AsyncSolrClient.scala
@@ -19,7 +19,7 @@ object ContentTypes {
 class AsyncSolrClient(url: String, factory: () => OkHttpClient = { () => new OkHttpClient() })
     (implicit protected val parser: ExpressionParser = new DefaultExpressionParser())
     extends IAsyncSolrClient {
-  
+
   private val httpClient: OkHttpClient = factory()
   private val normalizedUrl = if(url.endsWith("/")) url.substring(0, url.length - 1) else url
 
@@ -36,7 +36,7 @@ class AsyncSolrClient(url: String, factory: () => OkHttpClient = { () => new OkH
     req.setAction(AbstractUpdateRequest.ACTION.COMMIT, true, true)
     execute(httpClient, req, Promise[Unit]())
   }
-  
+
   /**
    * Rolled back the current session.
    */
@@ -60,7 +60,7 @@ class AsyncSolrClient(url: String, factory: () => OkHttpClient = { () => new OkH
    * Returns the result of asynchronous request to the future world via given Promise.
    */
   private def execute(httpClient: OkHttpClient, req: UpdateRequest, promise: Promise[Unit]): Future[Unit] = {
-    
+
     //val builder = httpClient.preparePost(normalizedUrl + "/update")
     val builder = new Request.Builder().url(normalizedUrl + "/update")
 
@@ -89,5 +89,5 @@ class AsyncSolrClient(url: String, factory: () => OkHttpClient = { () => new OkH
 
     promise.future
   }
-  
+
 }

--- a/src/main/scala/com/github/takezoe/solr/scala/async/AsyncUtils.scala
+++ b/src/main/scala/com/github/takezoe/solr/scala/async/AsyncUtils.scala
@@ -7,14 +7,14 @@ import okhttp3.{Call, Callback, OkHttpClient, Response}
 import scala.concurrent.Promise
 
 object AsyncUtils {
-  
+
   /**
    * A result handler implementation for AsyncHttpClient
    * which notifies the result of asynchronous request via Promise.
    */
   class CallbackHandler[T](httpClient: OkHttpClient, promise: Promise[T],
       success: Response => T = (x: Response) => ()) extends Callback {
-    
+
     override def onFailure(call: Call, e: IOException): Unit = {
       promise.failure(e)
     }
@@ -25,5 +25,5 @@ object AsyncUtils {
       response.close()
     }
   }
-  
+
 }

--- a/src/main/scala/com/github/takezoe/solr/scala/query/QueryUtils.scala
+++ b/src/main/scala/com/github/takezoe/solr/scala/query/QueryUtils.scala
@@ -1,7 +1,7 @@
 package com.github.takezoe.solr.scala.query
 
 object QueryUtils {
-  
+
   private lazy val specialCharacters =
     Set('+', '-', '&', '|',  '!', '(', ')', '{', '}', '[', ']', '^', '"', '~', '*', '?', ':')
 
@@ -19,5 +19,5 @@ object QueryUtils {
         case _ => Seq(c)
       }
     }.flatten.mkString
-    
+
 }

--- a/src/main/scala/com/github/takezoe/solr/scala/sample/AsyncSolrClientSample.scala
+++ b/src/main/scala/com/github/takezoe/solr/scala/sample/AsyncSolrClientSample.scala
@@ -13,20 +13,20 @@ object AsyncSolrClientSample extends App {
   val client = new AsyncSolrClient("http://localhost:8983/solr")
 
   val f1 = client.register(Map("id" -> "005", "name" -> "ThinkPad X1 Carbon", "manu" -> "Lenovo"))
-  
+
   val f2 = client.withTransaction {
     for {
         _ <- client.add(Map("id" -> "006", "name" -> "Nexus7 2012", "manu" -> "ASUS"))
         _ <- client.add(Map("id" -> "007", "name" -> "Nexus7 2013", "manu" -> "ASUS"))
     } yield ()
   }
-  
+
   val f3 = client.query("name:%name%")
         .fields("id", "manu", "name")
         .facetFields("manu")
         .sortBy("id", Order.asc)
         .getResultAsMap(Map("name" -> "ThinkPad X201s"))
-            
+
   f3.onComplete {
     case Success(result) => {
       println("count: " + result.numFound)

--- a/src/main/scala/com/github/takezoe/solr/scala/sample/SolrClientSample.scala
+++ b/src/main/scala/com/github/takezoe/solr/scala/sample/SolrClientSample.scala
@@ -38,7 +38,7 @@ object SolrClientSample extends App {
     println("  manu: " + doc.get("manu").getOrElse("<NULL>"))
     println("  name: " + doc("name"))
   }
-    
+
   // query (Map) with facet search
   val result2 = client.query("name:%name%")
         .fields("id", "manu", "name")

--- a/src/test/scala/com/github/takezoe/solr/scala/CaseClassMapperSuite.scala
+++ b/src/test/scala/com/github/takezoe/solr/scala/CaseClassMapperSuite.scala
@@ -27,7 +27,7 @@ class CaseClassMapperSuite extends FunSuite {
     assert(employee.`emp-name` == "takezoe")
     assert(employee.email == Some("takezoe@gmail.com"))
   }
-  
+
   test("class2map (Option is None)"){
     val map = CaseClassMapper.class2map(Employee(5678, "takezoe", None))
 

--- a/src/test/scala/com/github/takezoe/solr/scala/QueryBuilderBaseSuite.scala
+++ b/src/test/scala/com/github/takezoe/solr/scala/QueryBuilderBaseSuite.scala
@@ -4,14 +4,14 @@ import com.github.takezoe.solr.scala.query.DefaultExpressionParser
 import org.scalatest.FunSuite
 
 class QueryBuilderBaseSuite extends FunSuite {
-  
+
   test("copy"){
     implicit val parser = new DefaultExpressionParser()
     val queryBuilder = new TestQueryBuilder()
     val copied = queryBuilder.id("contentId")
                              .highlight("content", 200, "<b>", "</b>", 2)
                              .facetQuery("something:cool")
-    
+
     assert(copied.getId == "contentId")
     assert(copied.getHilightingField == "content")
     assert(copied.getQuery.getHighlight == true)
@@ -22,13 +22,13 @@ class QueryBuilderBaseSuite extends FunSuite {
     assert(copied.getQuery.getHighlightSnippets == 2)
     assert(copied.getQuery.getFacetQuery.contains("something:cool"))
   }
-  
+
   class TestQueryBuilder extends QueryBuilderBase[TestQueryBuilder]{
     protected def createCopy: TestQueryBuilder = new TestQueryBuilder()
     def getId = this.id
     def getQuery = this.solrQuery
     def getHilightingField = this.highlightField
   }
-  
+
 
 }

--- a/src/test/scala/com/github/takezoe/solr/scala/query/DefaultExpressionParserSuite.scala
+++ b/src/test/scala/com/github/takezoe/solr/scala/query/DefaultExpressionParserSuite.scala
@@ -13,10 +13,10 @@ class DefaultExpressionParserSuite extends FunSuite {
     val result = new DefaultExpressionParser().parse("(AA & BB | CC !DD)")
     assert(result == ASTAnd(ASTOr(ASTAnd(ASTWord("AA"), ASTWord("BB")), ASTWord("CC")), ASTNot(ASTWord("DD"))))
   }
-  
+
   test("Test for quatation"){
     val result = new DefaultExpressionParser().parse("(\"AA & BB\" |(\"(CC)\" !DD))")
     assert(result == ASTOr(ASTPhrase("AA & BB"), ASTAnd(ASTPhrase("(CC)"), ASTNot(ASTWord("DD")))))
   }
-  
+
 }

--- a/src/test/scala/com/github/takezoe/solr/scala/query/GoogleExpressionParserSuite.scala
+++ b/src/test/scala/com/github/takezoe/solr/scala/query/GoogleExpressionParserSuite.scala
@@ -13,10 +13,10 @@ class GoogleExpressionParserSuite extends FunSuite {
     val result = new GoogleExpressionParser().parse("(AA BB OR CC -DD)")
     assert(result == ASTAnd(ASTOr(ASTAnd(ASTWord("AA"), ASTWord("BB")), ASTWord("CC")), ASTNot(ASTWord("DD"))))
   }
-  
+
   test("Test for quatation"){
     val result = new GoogleExpressionParser().parse("(\"AA & BB\" OR(\"(CC)\" - DD))")
     assert(result == ASTOr(ASTPhrase("AA & BB"), ASTAnd(ASTPhrase("(CC)"), ASTNot(ASTWord("DD")))))
   }
-  
+
 }


### PR DESCRIPTION
Per https://github.com/takezoe/solr-scala-client/issues/53, i have added a `collection` method for all calls as well as tidied up `BatchRegister` to more cleanly call the appropriate method.  I found that when sending a null in (i swapped that out for `None`), it would still use the method that takes a collection, so the NPE still exists. I could be wrong about that portion, but the match felt the safest to me.

I think it's really unfortunate that the JavaClient allows for both instantiations as it leads to incredibly unsafe code, especially since the client is so cheap to create.  Personally i'm now creating the client with no collection in the URI and using all the `collection` methods.

I've tested this thoroughly and will add unit tests if this approach is is accepted.