### PR TITLE
for Scala 2.13.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: scala
+dist: xenial
 scala:
   - 2.11.12
   - 2.12.8
   - 2.13.0
 jdk:
-  - oraclejdk8
+  - openjdk8
   - openjdk11

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: scala
 scala:
   - 2.11.12
   - 2.12.8
-  - 2.13.0-RC1
+  - 2.13.0
 jdk:
   - oraclejdk8
   - openjdk11

--- a/build.sbt
+++ b/build.sbt
@@ -8,14 +8,14 @@ scalaVersion := "2.12.8"
 
 scalacOptions += "-feature"
 
-crossScalaVersions := Seq("2.11.12", "2.12.8", "2.13.0-RC1")
+crossScalaVersions := Seq("2.11.12", "2.12.8", "2.13.0")
 
 resolvers += Resolver.mavenLocal
 
 libraryDependencies ++= Seq(
   "org.apache.solr"         % "solr-solrj"               % "7.1.0",
   "com.squareup.okhttp3"    % "okhttp"                   % "3.9.1",
-  "org.scalatest"          %% "scalatest"                % "3.0.8-RC2" % "test",
+  "org.scalatest"          %% "scalatest"                % "3.0.8" % "test",
   "org.mockito"             % "mockito-core"             % "2.2.22"    % "test",
   "commons-logging"         % "commons-logging"          % "1.2"       % "runtime"
 )


### PR DESCRIPTION
If you look it good, please release it 😄 

- use openjdk instead of oraclejdk. see travis-ci/travis-ci#10290 (comment)

> oraclejdk8 is not preinstalled on Xenial anymore, and cannot be retrieved from Oracle itself anymore. We'd suggest using either openjdk, or the currently supported Oracle JDK.