### PR TITLE
Scala 2.12 and 2.13 scala-parser-combinators 2.0.0 are binary incompatible between some libraries

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,6 +24,8 @@ libraryDependencies ++= Seq(
 libraryDependencies ++= PartialFunction.condOpt(CrossVersion.partialVersion(scalaVersion.value)){
   case Some((2, 11)) =>
     "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.1"
+  case Some((2, v)) if v >= 12 =>
+    "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.2"
   case _ =>
     "org.scala-lang.modules" %% "scala-parser-combinators" % "2.0.0"
 }.toList


### PR DESCRIPTION
After upgrading to solr-scala-client 0.0.25 in Scala 2.13 environment, I got a dependency error.

```
[error] java.lang.RuntimeException: found version conflict(s) in library dependencies; some are suspected to be binary incompatible:
[error] 
[error]         * org.scala-lang.modules:scala-parser-combinators_2.13:2.0.0 (early-semver) is selected over {1.1.2, 1.1.2, 1.1.2, 1.1.2}
[error]             +- com.github.takezoe:solr-scala-client_2.13:0.0.25   (depends on 2.0.0)
[error]             +- org.scalikejdbc:scalikejdbc-core_2.13:3.5.0        (depends on 1.1.2)
[error]             +- com.typesafe.play:play_2.13:2.8.8                  (depends on 1.1.2)
[error]             +- com.typesafe.play:cachecontrol_2.13:2.0.0          (depends on 1.1.2)
[error]             +- com.typesafe:ssl-config-core_2.13:0.4.2            (depends on 1.1.2)
[error] 
[error] 
[error] this can be overridden using libraryDependencySchemes or evictionErrorLevel
[error]         at scala.sys.package$.error(package.scala:30)
[error]         at sbt.internal.LibraryManagement$.resolve$1(LibraryManagement.scala:89)
[error]         at sbt.internal.LibraryManagement$.$anonfun$cachedUpdate$12(LibraryManagement.scala:133)
[error]         at sbt.util.Tracked$.$anonfun$lastOutput$1(Tracked.scala:73)
[error]         at sbt.internal.LibraryManagement$.$anonfun$cachedUpdate$20(LibraryManagement.scala:146)
[error]         at scala.util.control.Exception$Catch.apply(Exception.scala:228)
[error]         at sbt.internal.LibraryManagement$.$anonfun$cachedUpdate$11(LibraryManagement.scala:146)
[error]         at sbt.internal.LibraryManagement$.$anonfun$cachedUpdate$11$adapted(LibraryManagement.scala:127)
[error]         at sbt.util.Tracked$.$anonfun$inputChangedW$1(Tracked.scala:219)
[error]         at sbt.internal.LibraryManagement$.cachedUpdate(LibraryManagement.scala:160)
[error]         at sbt.Classpaths$.$anonfun$updateTask0$1(Defaults.scala:3678)
[error]         at scala.Function1.$anonfun$compose$1(Function1.scala:49)
[error]         at sbt.internal.util.$tilde$greater.$anonfun$$u2219$1(TypeFunctions.scala:62)
[error]         at sbt.std.Transform$$anon$4.work(Transform.scala:68)
[error]         at sbt.Execute.$anonfun$submit$2(Execute.scala:282)
[error]         at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:23)
[error]         at sbt.Execute.work(Execute.scala:291)
[error]         at sbt.Execute.$anonfun$submit$1(Execute.scala:282)
[error]         at sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1(ConcurrentRestrictions.scala:265)
[error]         at sbt.CompletionService$$anon$2.call(CompletionService.scala:64)
[error]         at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
[error]         at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
[error]         at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
[error]         at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
[error]         at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
[error]         at java.base/java.lang.Thread.run(Thread.java:834)
[error] (update) found version conflict(s) in library dependencies; some are suspected to be binary incompatible:
[error] 
[error]         * org.scala-lang.modules:scala-parser-combinators_2.13:2.0.0 (early-semver) is selected over {1.1.2, 1.1.2, 1.1.2, 1.1.2}
[error]             +- com.github.takezoe:solr-scala-client_2.13:0.0.25   (depends on 2.0.0)
[error]             +- org.scalikejdbc:scalikejdbc-core_2.13:3.5.0        (depends on 1.1.2)
[error]             +- com.typesafe.play:play_2.13:2.8.8                  (depends on 1.1.2)
[error]             +- com.typesafe.play:cachecontrol_2.13:2.0.0          (depends on 1.1.2)
[error]             +- com.typesafe:ssl-config-core_2.13:0.4.2            (depends on 1.1.2)
[error] 
[error] 
[error] this can be overridden using libraryDependencySchemes or evictionErrorLevel
```

This PR will work with Scala 2.12 and 2.13.