### PR TITLE
Add sortBy overload for multiple sorting fields

### DIFF
--- a/src/main/scala/com/github/takezoe/solr/scala/QueryBuilderBase.scala
+++ b/src/main/scala/com/github/takezoe/solr/scala/QueryBuilderBase.scala
@@ -96,9 +96,9 @@ trait QueryBuilderBase[Repr <: QueryBuilderBase[Repr]] {
   /**
    * Sets multiple sorting field names and orders.
    *
-   * @param sortClauses a vector of fields and orders upon which to sort
+   * @param sortClauses fields and orders upon which to sort
    */
-  def sortBy(sortClauses: Iterable[(String, Order)]): Repr = {
+  def sortBy(sortClauses: (String, Order)*): Repr = {
     val ret = copy()
     val sorts = sortClauses.map(pair => new SolrQuery.SortClause(pair._1, pair._2)).toList.asJava
     ret.solrQuery.setSorts(sorts)

--- a/src/main/scala/com/github/takezoe/solr/scala/QueryBuilderBase.scala
+++ b/src/main/scala/com/github/takezoe/solr/scala/QueryBuilderBase.scala
@@ -94,6 +94,18 @@ trait QueryBuilderBase[Repr <: QueryBuilderBase[Repr]] {
   }
 
   /**
+   * Sets multiple sorting field names and orders.
+   *
+   * @param sortClauses a vector of fields and orders upon which to sort
+   */
+  def sortBy(sortClauses: Iterable[(String, Order)]): Repr = {
+    val ret = copy()
+    val sorts = sortClauses.map(pair => new SolrQuery.SortClause(pair._1, pair._2)).toList.asJava
+    ret.solrQuery.setSorts(sorts)
+    ret
+  }
+
+  /**
    * Sets grouping field names.
    *
    * @param fields field names

--- a/src/test/scala/com/github/takezoe/solr/scala/SolrIntegrationTest.scala
+++ b/src/test/scala/com/github/takezoe/solr/scala/SolrIntegrationTest.scala
@@ -63,10 +63,10 @@ class SolrIntegrationTest extends AnyFunSuite {
       // query with new sort
       val result3 = client.query("*:*")
         .fields("id", "manu", "name")
-        .sortBy(Vector(
+        .sortBy(
           ("manu", Order.asc),
           ("id", Order.asc)
-        ))
+        )
         .getResultAs[PC](null)
 
       val expect3 = List(

--- a/src/test/scala/com/github/takezoe/solr/scala/SolrIntegrationTest.scala
+++ b/src/test/scala/com/github/takezoe/solr/scala/SolrIntegrationTest.scala
@@ -41,7 +41,7 @@ class SolrIntegrationTest extends AnyFunSuite {
       client
         .add(PC("004", "Apple", "MacBook Pro"))
         .commit()
-      
+
       // query as case class
       val result2 = client.query("manu: %manu%")
         .fields("id", "manu", "name")
@@ -55,6 +55,29 @@ class SolrIntegrationTest extends AnyFunSuite {
       // verify
       assert(expect2 == result2.documents)
 
+      // register as case class
+      client
+        .add(PC("005", "Microsoft", "Surface Pro 7"))
+        .commit()
+
+      // query with new sort
+      val result3 = client.query("*:*")
+        .fields("id", "manu", "name")
+        .sortBy(Vector(
+          ("manu", Order.asc),
+          ("id", Order.asc)
+        ))
+        .getResultAs[PC](null)
+
+      val expect3 = List(
+        PC("004", "Apple", "MacBook Pro"),
+        PC("003", "Dell", "XPS 13"),
+        PC("001", "Lenovo", "ThinkPad X201s"),
+        PC("002", "Lenovo", "ThinkPad X220"),
+        PC("005", "Microsoft", "Surface Pro 7")
+      )
+
+      assert(expect3 == result3.documents)
     } finally {
       container.stop()
     }


### PR DESCRIPTION
The current implementation of `sortBy` does not allow for multiple sort fields and order to be specified for more advanced sorting use cases when ordering results.

This PR adds a new overload of `sortBy` that expects an `Iterable[(String, Order)]`. This is converted to a list of `SortClause` objects to be passed to `setSorts` when preparing the query.